### PR TITLE
added forceReadings() for force mode

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -267,6 +267,36 @@ float BME280::readTempF( void )
 
 //****************************************************************************//
 //
+//  Force Mode
+//
+//****************************************************************************//
+void BME280::forceReadings( void )
+{
+	//set Force mode
+	settings.runMode = 0x01;	//Table 25: register settings mode
+	uint8_t dataToWrite = 0;
+	dataToWrite = (settings.tempOverSample << 0x5) & 0xE0;
+	dataToWrite |= (settings.pressOverSample << 0x02) & 0x1C;
+	dataToWrite |= (settings.runMode) & 0x03;
+	writeRegister(BME280_CTRL_MEAS_REG, dataToWrite);
+
+	//sleep while measurements are happening
+	//(we'll use t_measure,max in "9.1 Measurement time" of the datasheet)
+	uint32_t t_measure_us = 1250;		// microseconds
+	if (settings.tempOverSample) {
+		t_measure_us += 2300 * settings.tempOverSample;
+	}
+	if (settings.pressOverSample) {
+		t_measure_us += 2300 * settings.pressOverSample + 575;
+	}
+	if (settings.humidOverSample) {
+		t_measure_us += 2300 * settings.humidOverSample + 575;
+	}
+	delay((t_measure_us / 1000) + 1);	// round up
+}
+
+//****************************************************************************//
+//
 //  Utility
 //
 //****************************************************************************//

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -166,6 +166,11 @@ class BME280
     float readTempC( void );
     float readTempF( void );
 
+	//Force the sensor to make readings right now. After this returns the
+	//sensor will be in sleep mode and you'll need to call this function again
+	//to get new readings.
+	void forceReadings( void );
+
     //The following utilities read and write
 
 	//ReadRegisterRegion takes a uint8 array address as input and reads


### PR DESCRIPTION
This adds a `forceReadings()` method which puts the sensor into force mode. When this happens the BME reads the sensors, stores the results in the data registers, then goes to sleep. Another call to `forceReadings()` is then needed to cause the sensor to read again.

Using this I saw the device go from using a steady ~400uA to a base of ~0.4uA and spiking to ~50uA. (OK, my multimeter is pretty cheap, as is my EE knowledge :smile:) I was measuring 3 times a second with no filtering and 1x sampling of all three readings.
