### PR TITLE
Changed float methods to return better precision

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -179,8 +179,7 @@ float BME280::readFloatPressure( void )
 	var2 = (((int64_t)calibration.dig_P8) * p_acc) >> 19;
 	p_acc = ((p_acc + var1 + var2) >> 8) + (((int64_t)calibration.dig_P7)<<4);
 	
-	p_acc = p_acc >> 8; // /256
-	return (float)p_acc;
+	return (float)p_acc / 256.0;
 	
 }
 
@@ -223,7 +222,7 @@ float BME280::readFloatHumidity( void )
 	var1 = (var1 < 0 ? 0 : var1);
 	var1 = (var1 > 419430400 ? 419430400 : var1);
 
-	return (float)((var1>>12) >> 10);
+	return (float)(var1>>12) / 1024.0;
 
 }
 


### PR DESCRIPTION
This improves the precision of `readFloatPressure` and `readFloatHumidity` return values.

I've now checked that all bits are valid for inclusion in the return value.

Fixes #3
