### PR TITLE
Calibration value H6 should be a signed char.

### DIFF
--- a/examples/I2C_ReadAllData/I2C_ReadAllData.ino
+++ b/examples/I2C_ReadAllData/I2C_ReadAllData.ino
@@ -170,7 +170,7 @@ void setup()
 	Serial.println(mySensor.calibration.dig_H4);
 	Serial.print("dig_H5, int16: ");
 	Serial.println(mySensor.calibration.dig_H5);
-	Serial.print("dig_H6, uint8: ");
+	Serial.print("dig_H6, int8: ");
 	Serial.println(mySensor.calibration.dig_H6);
 		
 	Serial.println();

--- a/examples/SketchesWithLCD/LCD_PressureTemperature/LCD_PressureTemperature.ino
+++ b/examples/SketchesWithLCD/LCD_PressureTemperature/LCD_PressureTemperature.ino
@@ -203,7 +203,7 @@ void setup()
 	Serial.println(mySensor.calibration.dig_H4);
 	Serial.print("dig_H5, int16: ");
 	Serial.println(mySensor.calibration.dig_H5);
-	Serial.print("dig_H6, uint8: ");
+	Serial.print("dig_H6, int8: ");
 	Serial.println(mySensor.calibration.dig_H6);
 		
 	Serial.println();

--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -115,7 +115,7 @@ uint8_t BME280::begin()
 	calibration.dig_H3 = ((uint8_t)(readRegister(BME280_DIG_H3_REG)));
 	calibration.dig_H4 = ((int16_t)((readRegister(BME280_DIG_H4_MSB_REG) << 4) + (readRegister(BME280_DIG_H4_LSB_REG) & 0x0F)));
 	calibration.dig_H5 = ((int16_t)((readRegister(BME280_DIG_H5_MSB_REG) << 4) + ((readRegister(BME280_DIG_H4_LSB_REG) >> 4) & 0x0F)));
-	calibration.dig_H6 = ((uint8_t)readRegister(BME280_DIG_H6_REG));
+	calibration.dig_H6 = ((int8_t)readRegister(BME280_DIG_H6_REG));
 
 	//Set the oversampling control words.
 	//config will only be writeable in sleep mode, so first insure that.

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -129,7 +129,7 @@ struct SensorCalibration
 	uint8_t dig_H3;
 	int16_t dig_H4;
 	int16_t dig_H5;
-	uint8_t dig_H6;
+	int8_t dig_H6;
 	
 };
 


### PR DESCRIPTION
See BME280 datasheet, pg 23.

In the code, H6 is specified as a uint8_t, but the datasheet says H6 is a signed char. This PR changes H6 to be an int8_t

The change compiles and runs correctly with a SparkFun BME280 breakout.