### PR TITLE
Added ability to select Wire bus in begin function

### DIFF
--- a/examples/I2C_DeltaAltitude/I2C_DeltaAltitude.ino
+++ b/examples/I2C_DeltaAltitude/I2C_DeltaAltitude.ino
@@ -125,7 +125,7 @@ void setup()
 	Serial.print("Starting BME280... result of .begin(): 0x");
 	delay(10);  //Make sure sensor had enough time to turn on. BME280 requires 2ms to start up.
 	//Calling .begin() causes the settings to be loaded
-	Serial.println(mySensor.begin(), HEX);
+	Serial.println(mySensor.begin(), HEX);    //mySensor.begin(&Wire), use &Wire1, &Wire2 for different Wire Busses
 
 	Serial.println();
 

--- a/examples/I2C_ReadAllData/I2C_ReadAllData.ino
+++ b/examples/I2C_ReadAllData/I2C_ReadAllData.ino
@@ -96,7 +96,7 @@ void setup()
 	
 	//Calling .begin() causes the settings to be loaded
 	delay(10);  //Make sure sensor had enough time to turn on. BME280 requires 2ms to start up.
-	Serial.println(mySensor.begin(), HEX);
+	Serial.println(mySensor.begin(), HEX);  //mySensor.begin(&Wire), use &Wire1, &Wire2 for different Wire Busses
 
 	Serial.print("Displaying ID, reset and ctrl regs\n");
 	

--- a/examples/I2C_and_SPI_Multisensor/I2C_and_SPI_Multisensor.ino
+++ b/examples/I2C_and_SPI_Multisensor/I2C_and_SPI_Multisensor.ino
@@ -92,9 +92,9 @@ void setup()
 	delay(10);  //Make sure sensor had enough time to turn on. BME280 requires 2ms to start up.
 	//Calling .begin() causes the settings to be loaded
 	Serial.print("Sensor A: 0x");
-	Serial.println(mySensorA.begin(), HEX);
+	Serial.println(mySensorA.begin(), HEX); //mySensor.begin(&Wire), use &Wire1, &Wire2 for different Wire Busses
 	Serial.print("Sensor B: 0x");
-	Serial.println(mySensorB.begin(), HEX);
+	Serial.println(mySensorB.begin(), HEX); //SensorB is in SPI Mode
 
 
 }

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -24,6 +24,7 @@ Distributed as-is; no warranty is given.
 #define __BME280_H__
 
 #include "stdint.h"
+#include "Wire.h"
 
 #define I2C_MODE 0
 #define SPI_MODE 1
@@ -129,7 +130,7 @@ struct SensorCalibration
 	uint8_t dig_H3;
 	int16_t dig_H4;
 	int16_t dig_H5;
-	uint8_t dig_H6;
+	int8_t dig_H6;
 	
 };
 
@@ -150,7 +151,7 @@ class BME280
 	
 	//Call to apply SensorSettings.
 	//This also gets the SensorCalibration constants
-    uint8_t begin( void );
+	uint8_t begin(TwoWire *theWire = &Wire);
 
 	//Software reset routine
 	void reset( void );
@@ -178,7 +179,9 @@ class BME280
 	int16_t readRegisterInt16( uint8_t offset );
 	//Writes a byte;
     void writeRegister(uint8_t, uint8_t);
-    
+	
+  private:
+	TwoWire *wire;
 };
 
 


### PR DESCRIPTION
Added ability to select wire bus in setup.
1. mySensor.begin() defaults to Wire
2. mySensor.begin(&Wire1) sets I2C to use Wire1
3. mySensor.begin(&Wire2) sets I2C to use Wire2

Also incorporated Pull Request 8.

Hope this helps someone.
Mike