### PR TITLE
Improve SPI communication using SPISettings

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -86,24 +86,6 @@ uint8_t BME280::begin()
 	case SPI_MODE:
 		// start the SPI library:
 		SPI.begin();
-		#ifdef ARDUINO_ARCH_ESP32
-		SPI.setFrequency(1000000);
-		// Data is read and written MSb first.
-		SPI.setBitOrder(SPI_MSBFIRST);
-		// Like the standard arduino/teensy comment below, mode0 seems wrong according to standards
-		// but conforms to the timing diagrams when used for the ESP32
-		SPI.setDataMode(SPI_MODE0);
-		#else
-		// Maximum SPI frequency is 10MHz, could divide by 2 here:
-		SPI.setClockDivider(SPI_CLOCK_DIV32);
-		// Data is read and written MSb first.
-		SPI.setBitOrder(MSBFIRST);
-		// Data is captured on rising edge of clock (CPHA = 0)
-		// Base value of the clock is HIGH (CPOL = 1)
-		// This was SPI_MODE3 for RedBoard, but I had to change to
-		// MODE0 for Teensy 3.1 operation
-		SPI.setDataMode(SPI_MODE3);
-		#endif
 		// initialize the  data ready and chip select pins:
 		pinMode(settings.chipSelectPin, OUTPUT);
 		digitalWrite(settings.chipSelectPin, HIGH);
@@ -580,6 +562,7 @@ void BME280::readRegisterRegion(uint8_t *outputPointer , uint8_t offset, uint8_t
 		break;
 
 	case SPI_MODE:
+		SPI.beginTransaction(settings.spiSettings);
 		// take the chip select low to select the device:
 		digitalWrite(settings.chipSelectPin, LOW);
 		// send the device the register you want to read:
@@ -593,6 +576,7 @@ void BME280::readRegisterRegion(uint8_t *outputPointer , uint8_t offset, uint8_t
 		}
 		// take the chip select high to de-select:
 		digitalWrite(settings.chipSelectPin, HIGH);
+		SPI.endTransaction();
 		break;
 
 	default:
@@ -641,14 +625,7 @@ uint8_t BME280::readRegister(uint8_t offset)
 		break;
 
 	case SPI_MODE:
-		// take the chip select low to select the device:
-		digitalWrite(settings.chipSelectPin, LOW);
-		// send the device the register you want to read:
-		SPI.transfer(offset | 0x80);  //Ored with "read request" bit
-		// send a value of 0 to read the first byte returned:
-		result = SPI.transfer(0x00);
-		// take the chip select high to de-select:
-		digitalWrite(settings.chipSelectPin, HIGH);
+		readRegisterRegion(&result, offset, 1);
 		break;
 
 	default:
@@ -693,6 +670,7 @@ void BME280::writeRegister(uint8_t offset, uint8_t dataToWrite)
 		break;
 		
 	case SPI_MODE:
+		SPI.beginTransaction(settings.spiSettings);
 		// take the chip select low to select the device:
 		digitalWrite(settings.chipSelectPin, LOW);
 		// send the device the register you want to read:
@@ -702,6 +680,7 @@ void BME280::writeRegister(uint8_t offset, uint8_t dataToWrite)
 		// decrement the number of bytes left to read:
 		// take the chip select high to de-select:
 		digitalWrite(settings.chipSelectPin, HIGH);
+		SPI.endTransaction();
 		break;
 
 	default:

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -46,6 +46,18 @@ TODO:
 #define I2C_MODE 0
 #define SPI_MODE 1
 
+#ifndef BME280_SPI_CLOCK
+#ifdef ARDUINO_ARCH_ESP32
+#define BME280_SPI_CLOCK 1000000
+#else
+#define BME280_SPI_CLOCK 500000
+#endif
+#endif
+
+#ifndef BME280_SPI_MODE
+#define BME280_SPI_MODE SPI_MODE0
+#endif
+
 #define NO_WIRE 0
 #define HARD_WIRE 1
 #define SOFT_WIRE 2
@@ -120,7 +132,8 @@ struct BME280_SensorSettings
     uint8_t commInterface;
     uint8_t I2CAddress;
     uint8_t chipSelectPin;
-	
+	SPISettings spiSettings{BME280_SPI_CLOCK, MSBFIRST, BME280_SPI_MODE};
+
 	//Deprecated settings
 	uint8_t runMode;
 	uint8_t tStandby;


### PR DESCRIPTION
Using SPISettings together with begin/endTransaction allows using
multiple systems communicating over the same SPI bus. Thus far, the
initial SPI configuration was overridden by other systems that
configured SPI.

Additionally, due to compiler and linker optimizations, adjusting the
SPI settings via BME280_SPI_CLOCK, a much smaller memory footprint
is possible.

Finally, allow modification of the SPI mode by defining BME280_SPI_MODE.