### PR TITLE
Add method for setting temperature correction

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -47,7 +47,7 @@ BME280::BME280( void )
 	settings.tempOverSample = 1;
 	settings.pressOverSample = 1;
 	settings.humidOverSample = 1;
-    settings.tempCorrection = 0.0; // correction of temperature - added to the result
+	settings.tempCorrection = 0.f; // correction of temperature - added to the result
 }
 
 
@@ -452,6 +452,11 @@ float BME280::readFloatHumidity( void )
 //  Temperature Section
 //
 //****************************************************************************//
+
+void BME280::setTemperatureCorrection(float corr)
+{
+	settings.tempCorrection = corr;
+}
 
 float BME280::readTempC( void )
 {

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -223,7 +223,8 @@ class BME280
 	
 	float readFloatHumidity( void );
 
-	//Temperature related methods
+    //Temperature related methods
+    void setTemperatureCorrection(float corr);
     float readTempC( void );
     float readTempF( void );
 


### PR DESCRIPTION
This is the only value being set in constructor which cannot be changed otherwise. In order to avoid changing constructor each time it would be handy to have a setter method. Direct access to settings seems awkward, as it could interfere with other things.