### PR TITLE
Include math.h

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -20,6 +20,7 @@ Distributed as-is; no warranty is given.
 ******************************************************************************/
 //See SparkFunBME280.h for additional topology notes.
 
+#include <math.h>
 #include "SparkFunBME280.h"
 
 //****************************************************************************//


### PR DESCRIPTION
`SparkFunBME280.cpp` uses math functions `pow`, `log` and `log10`. This produces
errors such as "pow was not declared in this scope". Found this while
packaging this library for RIOT-OS.

The library works with Arduino because `math.h` is included somewhere
else. But I think it's better or more correct to include the headers for
the functions used.

Fixes #48