### PR TITLE
firstly read temperature for avoiding wrong calculation

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -475,6 +475,10 @@ float BME280::readFloatAltitudeMeters( void )
   // see NRLMSISE-00. That's why it is the "international" formula, not "interplanetary".
   // Sparkfun is not liable for incorrect altitude calculations from this
   // code on those planets. Interplanetary selfies are welcome, however.
+	
+	// firstly read temperature for avoiding wrong calculation
+	readTempC();
+	
 	heightOutput = ((float)-44330.77)*(pow(((float)readFloatPressure()/(float)_referencePressure), 0.190263) - (float)1); //Corrected, see issue 30
 	return heightOutput;
 	


### PR DESCRIPTION
I have used the library and it was giving wrong altitude values because of not calling the readTempC() before calling readFloatAltitudeMeters(). Then I have called it and it has been fixed.