### PR TITLE
change byte to uint8_t to avoid naming conflict with ESP8266 toolchain

### DIFF
--- a/src/SparkFunBME280.cpp
+++ b/src/SparkFunBME280.cpp
@@ -366,7 +366,7 @@ void BME280::reset( void )
 //Read all sensor registers as a burst. See BME280 Datasheet section 4. Data readout
 //tempScale = 0 for Celsius scale (default setting)
 //tempScale = 1 for Fahrenheit scale
-void BME280::readAllMeasurements(BME280_SensorMeasurements *measurements, byte tempScale){
+void BME280::readAllMeasurements(BME280_SensorMeasurements *measurements, uint8_t tempScale){
 	
 	uint8_t dataBurst[8];
 	readRegisterRegion(dataBurst, BME280_MEASUREMENTS_REG, 8);

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -224,7 +224,7 @@ class BME280
 	
 	//Software reset routine
 	void reset( void );
-		void readAllMeasurements(BME280_SensorMeasurements *measurements, byte tempScale = 0);
+	void readAllMeasurements(BME280_SensorMeasurements *measurements, uint8_t tempScale = 0);
 	
     //Returns the values as floats.
     float readFloatPressure( void );


### PR DESCRIPTION
I am using this library with ESP8266. The latest version (2.0.9) was causing a naming conflict with the Arduino toolchain.
This commit should fix the issue for ESP8266 users.

```
Compiling .pio\build\D1Mini\lib2ea\SparkFun BME280@src-c50b57925febe6e2911b52ed12ba3848\SparkFunBME280.cpp.o
Compiling .pio\build\D1Mini\lib3db\BME280\bme280.cpp.o
In file included from lib\BME280/bme280.h:10,
                 from src\main.cpp:12:
.pio\libdeps\D1Mini\SparkFun BME280@src-c50b57925febe6e2911b52ed12ba3848\src/SparkFunBME280.h:227:68: error: reference to 'byte' is ambiguous
  227 |  void readAllMeasurements(BME280_SensorMeasurements *measurements, byte tempScale = 0);
      |                                                                    ^~~~
In file included from c:\users\xxx\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\cmath:42,
                 from c:\users\xxx\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\math.h:36,
                 from C:\Users\xxx\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Arduino.h:34,
                 from src\main.cpp:3:
c:\users\xxx\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits\cpp_type_traits.h:404:30: note: candidates are: 'enum class std::byte' 
  404 |   enum class byte : unsigned char;
      |                              ^~~~
In file included from src\main.cpp:3:
C:\Users\xxx\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Arduino.h:160:17: note:                 'typedef uint8_t byte'
  160 | typedef uint8_t byte;
      |                 ^~~~
In file included from lib\BME280/bme280.h:10,
                 from src\main.cpp:12:
.pio\libdeps\D1Mini\SparkFun BME280@src-c50b57925febe6e2911b52ed12ba3848\src/SparkFunBME280.h:227:68: error: 'byte' has not been declared
  227 |  void readAllMeasurements(BME280_SensorMeasurements *measurements, byte tempScale = 0);
      |                                                                    ^~~~
*** [.pio\build\D1Mini\src\main.cpp.o] Error 1
```