### PR TITLE
Optionally Specify SPIClass in beginSPI

### DIFF
--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -58,7 +58,7 @@ TODO:
 #define BME280_SPI_MODE SPI_MODE0
 #endif
 
-#define NO_WIRE nullptr
+#define NO_WIRE 0
 #define HARD_WIRE 1
 #define SOFT_WIRE 2
 
@@ -265,11 +265,11 @@ private:
 	void readTempFFromBurst(uint8_t buffer[], BME280_SensorMeasurements *measurements);
 
     uint8_t _wireType = HARD_WIRE; //Default to Wire.h
-    TwoWire *_hardPort = nullptr; //The generic connection to user's chosen I2C hardware
+    TwoWire *_hardPort = NO_WIRE; //The generic connection to user's chosen I2C hardware
 	SPIClass *_spiPort = &SPI; //The generic connection to user's chosen SPI hardware
     
 	#ifdef SoftwareWire_h
-	SoftwareWire *_softPort = nullptr; //Or, the generic connection to software wire port
+	SoftwareWire *_softPort = NO_WIRE; //Or, the generic connection to software wire port
 	#endif
 	
 	float _referencePressure = 101325.0; //Default but is changeable

--- a/src/SparkFunBME280.h
+++ b/src/SparkFunBME280.h
@@ -58,7 +58,7 @@ TODO:
 #define BME280_SPI_MODE SPI_MODE0
 #endif
 
-#define NO_WIRE 0
+#define NO_WIRE nullptr
 #define HARD_WIRE 1
 #define SOFT_WIRE 2
 
@@ -199,7 +199,7 @@ class BME280
 	//Call to apply BME280_SensorSettings.
 	//This also gets the SensorCalibration constants
     uint8_t begin( void );
-    bool beginSPI(uint8_t csPin); //Communicate using SPI
+    bool beginSPI(uint8_t csPin, SPIClass &spiPort=SPI); //Communicate using SPI
     bool beginI2C(TwoWire &wirePort = Wire); //Called when user provides Wire port
     
 	#ifdef SoftwareWire_h
@@ -265,10 +265,11 @@ private:
 	void readTempFFromBurst(uint8_t buffer[], BME280_SensorMeasurements *measurements);
 
     uint8_t _wireType = HARD_WIRE; //Default to Wire.h
-    TwoWire *_hardPort = NO_WIRE; //The generic connection to user's chosen I2C hardware
+    TwoWire *_hardPort = nullptr; //The generic connection to user's chosen I2C hardware
+	SPIClass *_spiPort = &SPI; //The generic connection to user's chosen SPI hardware
     
 	#ifdef SoftwareWire_h
-	SoftwareWire *_softPort = NO_WIRE; //Or, the generic connection to software wire port
+	SoftwareWire *_softPort = nullptr; //Or, the generic connection to software wire port
 	#endif
 	
 	float _referencePressure = 101325.0; //Default but is changeable


### PR DESCRIPTION
For I2C we can pass a TwoWire object to the beginI2C() method.
However for SPI we can't pass the SPIClass and SPI is hard coded!

There are quite some processors that have multiple SPI ports and the SPIClass is part of the [Core Arduino API].(https://github.com/arduino/ArduinoCore-API/blob/cd91833d90b4fe50e428021ba5051e2b7ceafc84/api/HardwareSPI.h)

I extended the method to be

```C++
    bool beginSPI(uint8_t csPin, SPIClass &spiPort=SPI); //Communicate using SPI
```