### PR TITLE
Make compatible with esp-idf arduino as a component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB SOURCES src/*.cpp)
+idf_component_register(
+    SRCS ${SOURCES}
+    INCLUDE_DIRS src
+    REQUIRES arduino
+)


### PR DESCRIPTION
A handy feature for users who can just include your headers in esp-idf + arduino as a component.